### PR TITLE
Hopefully fix infinite loop when parsing rows with multiple variable-sized columns

### DIFF
--- a/src/main/java/mdbtools/libmdb/Data.java
+++ b/src/main/java/mdbtools/libmdb/Data.java
@@ -381,7 +381,7 @@ public class Data
           }
           else
           {
-           len = mdb.pg_buf[col_ptr - var_cols_found ] - col_start;
+           len = mdb.pg_buf[col_ptr - var_cols_found + 1] - col_start;
           }
           if (len<0)
           len+=256;


### PR DESCRIPTION
See https://trello.com/c/VWs0uUp8/302-infinite-loop-during-mtb-file-parsing.  Not sure what (if anything) this might break, so further work may be needed here.